### PR TITLE
Add get data for website endpoint

### DIFF
--- a/ProcessText/ProcessTextFunc.Tests/ProcessTextFunc.Tests.csproj
+++ b/ProcessText/ProcessTextFunc.Tests/ProcessTextFunc.Tests.csproj
@@ -1,22 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
-
     <IsPackable>false</IsPackable>
   </PropertyGroup>
-
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0"/>
+    <PackageReference Include="xunit" Version="2.4.1"/>
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Moq" Version="4.13.1" />
+    <PackageReference Include="Moq" Version="4.13.1"/>
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118"/>
   </ItemGroup>
-
   <ItemGroup>
-    <ProjectReference Include="..\ProcessTextFunc\ProcessTextFunc.csproj" />
+    <ProjectReference Include="..\ProcessTextFunc\ProcessTextFunc.csproj"/>
   </ItemGroup>
 </Project>

--- a/ProcessText/ProcessTextFunc/Contracts/GetTextResponse.cs
+++ b/ProcessText/ProcessTextFunc/Contracts/GetTextResponse.cs
@@ -1,4 +1,4 @@
-// <copyright file="ProcessTextRequest.cs" company="PlaceholderCompany">
+// <copyright file="GetTextResponse.cs" company="PlaceholderCompany">
 // Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
 
@@ -8,7 +8,7 @@ namespace ProcessTextFunc.Contracts
     using Newtonsoft.Json;
 
     [Serializable]
-    public class ProcessTextRequest
+    public class GetTextResponse
     {
         [JsonProperty("author")]
         public string Author { get; set; }
@@ -63,6 +63,9 @@ namespace ProcessTextFunc.Contracts
 
         [JsonProperty("overall_score")]
         public string OverallScore { get; set; }
+
+        [JsonProperty("processed_time")]
+        public DateTime ProcessedTime { get; set; }
 
         [JsonProperty("sentence_count")]
         public int SentenceCount { get; set; }

--- a/ProcessText/ProcessTextFunc/Contracts/ProcessTextRequest.cs
+++ b/ProcessText/ProcessTextFunc/Contracts/ProcessTextRequest.cs
@@ -50,5 +50,7 @@ namespace ProcessTextFunc.Contracts
         public float SmogIndex {get; set;}
         [JsonProperty("overall_score")]
         public string OverallScore {get; set;}
+        [JsonProperty("url")]
+        public string Url {get; set;}
     }
 }

--- a/ProcessText/ProcessTextFunc/Contracts/ProcessedText.cs
+++ b/ProcessText/ProcessTextFunc/Contracts/ProcessedText.cs
@@ -6,6 +6,8 @@ namespace ProcessTextFunc.Contracts
     [Serializable]
     public class ProcessedText
     {
+        [JsonProperty("id")]
+        public string Id {get; set;}
         [JsonProperty("author")]
         public string Author {get; set;}
         [JsonProperty("content")]
@@ -52,5 +54,7 @@ namespace ProcessTextFunc.Contracts
         public string OverallScore {get; set;}
         [JsonProperty("processed_time")]
         public DateTime ProcessedTime {get; set;}
+        [JsonProperty("url")]
+        public string Url {get; set;}
     }
 }

--- a/ProcessText/ProcessTextFunc/Contracts/ProcessedText.cs
+++ b/ProcessText/ProcessTextFunc/Contracts/ProcessedText.cs
@@ -1,60 +1,88 @@
-using System;
-using Newtonsoft.Json;
+// <copyright file="ProcessedText.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
 
 namespace ProcessTextFunc.Contracts
 {
+    using System;
+    using Newtonsoft.Json;
+
     [Serializable]
     public class ProcessedText
     {
-        [JsonProperty("id")]
-        public string Id {get; set;}
         [JsonProperty("author")]
-        public string Author {get; set;}
-        [JsonProperty("content")]
-        public string Content {get; set;}
-        [JsonProperty("date_published")]
-        public DateTime DatePublished {get; set;}
-        [JsonProperty("domain")]
-        public string Domain {get; set;}
-        [JsonProperty("excerpt")]
-        public string Excerpt {get; set;}
-        [JsonProperty("lead_image_url")]
-        public string LeadImageUrl {get; set;}
-        [JsonProperty("title")]
-        public string Title {get; set;}
-        [JsonProperty("syllable_count")]
-        public int SyllableCount {get; set;}
-        [JsonProperty("lexicon_count")]
-        public int LexiconCount {get; set;}
-        [JsonProperty("sentence_count")]
-        public int SentenceCount {get; set;}
-        [JsonProperty("average_sentence_length")]
-        public float AverageSentenceLength {get; set;}
-        [JsonProperty("lix_readability_index")]
-        public float LixReadabilityIndex {get; set;}
-        [JsonProperty("flesch_ease")]
-        public float FleshEase {get; set;}
-        [JsonProperty("fleschkincaid_grade")]
-        public float FleschKincaidGrade {get; set;}
-        [JsonProperty("coleman_liau_index")]
-        public float ColemanLiauIndex {get; set;}
+        public string Author { get; set; }
+
         [JsonProperty("automated_readability_index")]
-        public float AutomatedReadabilityIndex {get; set;}
+        public float AutomatedReadabilityIndex { get; set; }
+
+        [JsonProperty("average_sentence_length")]
+        public float AverageSentenceLength { get; set; }
+
+        [JsonProperty("coleman_liau_index")]
+        public float ColemanLiauIndex { get; set; }
+
+        [JsonProperty("content")]
+        public string Content { get; set; }
+
         [JsonProperty("dale_chall_readability_score")]
-        public float DaleChallReadabilityScore {get; set;}
+        public float DaleChallReadabilityScore { get; set; }
+
+        [JsonProperty("date_published")]
+        public DateTime DatePublished { get; set; }
+
         [JsonProperty("difficult_words")]
-        public int DifficultWords {get; set;}
-        [JsonProperty("linsear_write_index")]
-        public float LinsearWriteIndex {get; set;}
+        public int DifficultWords { get; set; }
+
+        [JsonProperty("domain")]
+        public string Domain { get; set; }
+
+        [JsonProperty("excerpt")]
+        public string Excerpt { get; set; }
+
+        [JsonProperty("flesch_ease")]
+        public float FleshEase { get; set; }
+
+        [JsonProperty("fleschkincaid_grade")]
+        public float FleschKincaidGrade { get; set; }
+
         [JsonProperty("gunning_fog_index")]
-        public float GunningFoxIndex {get; set;}
-        [JsonProperty("smog_index")]
-        public float SmogIndex {get; set;}
+        public float GunningFoxIndex { get; set; }
+
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        [JsonProperty("lead_image_url")]
+        public string LeadImageUrl { get; set; }
+
+        [JsonProperty("lexicon_count")]
+        public int LexiconCount { get; set; }
+
+        [JsonProperty("linsear_write_index")]
+        public float LinsearWriteIndex { get; set; }
+
+        [JsonProperty("lix_readability_index")]
+        public float LixReadabilityIndex { get; set; }
+
         [JsonProperty("overall_score")]
-        public string OverallScore {get; set;}
+        public string OverallScore { get; set; }
+
         [JsonProperty("processed_time")]
-        public DateTime ProcessedTime {get; set;}
+        public DateTime ProcessedTime { get; set; }
+
+        [JsonProperty("sentence_count")]
+        public int SentenceCount { get; set; }
+
+        [JsonProperty("smog_index")]
+        public float SmogIndex { get; set; }
+
+        [JsonProperty("syllable_count")]
+        public int SyllableCount { get; set; }
+
+        [JsonProperty("title")]
+        public string Title { get; set; }
+
         [JsonProperty("url")]
-        public string Url {get; set;}
+        public string Url { get; set; }
     }
 }

--- a/ProcessText/ProcessTextFunc/Exceptions/MissingPropertyException.cs
+++ b/ProcessText/ProcessTextFunc/Exceptions/MissingPropertyException.cs
@@ -1,17 +1,24 @@
-using System;
+// <copyright file="MissingPropertyException.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
 
 namespace ProcessTextFunc.Exceptions
 {
-    [Serializable()]
+    using System;
+
+    [Serializable]
     public class MissingPropertyException : Exception
     {
         public MissingPropertyException() : base() { }
+
         public MissingPropertyException(string message) : base(message) { }
+
         public MissingPropertyException(string message, Exception inner) : base(message, inner) { }
 
         // A constructor is needed for serialization when an
         // exception propagates from a remoting server to the client.
-        protected MissingPropertyException(System.Runtime.Serialization.SerializationInfo info,
+        protected MissingPropertyException(
+            System.Runtime.Serialization.SerializationInfo info,
             System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
     }
 }

--- a/ProcessText/ProcessTextFunc/Exceptions/MissingPropertyException.cs
+++ b/ProcessText/ProcessTextFunc/Exceptions/MissingPropertyException.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace ProcessTextFunc.Exceptions
+{
+    [Serializable()]
+    public class MissingPropertyException : Exception
+    {
+        public MissingPropertyException() : base() { }
+        public MissingPropertyException(string message) : base(message) { }
+        public MissingPropertyException(string message, Exception inner) : base(message, inner) { }
+
+        // A constructor is needed for serialization when an
+        // exception propagates from a remoting server to the client.
+        protected MissingPropertyException(System.Runtime.Serialization.SerializationInfo info,
+            System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
+    }
+}

--- a/ProcessText/ProcessTextFunc/GetText.cs
+++ b/ProcessText/ProcessTextFunc/GetText.cs
@@ -1,13 +1,18 @@
-using System.Threading.Tasks;
-using Microsoft.Azure.WebJobs;
-using Microsoft.Azure.WebJobs.Extensions.Http;
-using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Logging;
-using ProcessTextFunc.Contracts;
-using Microsoft.AspNetCore.Mvc;
+// <copyright file="GetText.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
 
 namespace ProcessTextFunc
 {
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Azure.WebJobs;
+    using Microsoft.Azure.WebJobs.Extensions.Http;
+    using Microsoft.Extensions.Logging;
+    using ProcessTextFunc.Contracts;
+    using ProcessTextFunc.Utils;
+
     public static class GetProcessedText
     {
         [FunctionName("GetProcessedText")]
@@ -20,14 +25,14 @@ namespace ProcessTextFunc
                 collectionName: "Web",
                 ConnectionStringSetting = "tkawchak-textanalysis_DOCUMENTDB",
                 Id = "{Query.id}",
-                PartitionKey = "{Query.domain}"
-            )] ProcessedText document)
+                PartitionKey = "{Query.domain}")] ProcessedText document)
         {
             log.LogInformation("C# GetProcessedText function received request.");
 
             if (document != null)
             {
-                return new OkObjectResult(document);
+                var response = Converters.ConvertProcessedTextDocumentToGetTextResponse(document);
+                return new OkObjectResult(response);
             }
             else
             {

--- a/ProcessText/ProcessTextFunc/GetText.cs
+++ b/ProcessText/ProcessTextFunc/GetText.cs
@@ -16,11 +16,11 @@ namespace ProcessTextFunc
                 AuthorizationLevel.Function, "get", Route = null)] HttpRequest request,
             ILogger log,
             [CosmosDB(
-                databaseName: "AzureFunConnectionTest",
-                collectionName: "testDocuments",
+                databaseName: "TextContent",
+                collectionName: "Web",
                 ConnectionStringSetting = "tkawchak-textanalysis_DOCUMENTDB",
                 Id = "{Query.id}",
-                PartitionKey = "{Query.partitionKey}"
+                PartitionKey = "{Query.domain}"
             )] ProcessedText document)
         {
             log.LogInformation("C# GetProcessedText function received request.");

--- a/ProcessText/ProcessTextFunc/GetText.cs
+++ b/ProcessText/ProcessTextFunc/GetText.cs
@@ -1,0 +1,38 @@
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.Http;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using ProcessTextFunc.Contracts;
+using Microsoft.AspNetCore.Mvc;
+
+namespace ProcessTextFunc
+{
+    public static class GetProcessedText
+    {
+        [FunctionName("GetProcessedText")]
+        public static async Task<IActionResult> Run(
+            [HttpTrigger(
+                AuthorizationLevel.Function, "get", Route = null)] HttpRequest request,
+            ILogger log,
+            [CosmosDB(
+                databaseName: "AzureFunConnectionTest",
+                collectionName: "testDocuments",
+                ConnectionStringSetting = "tkawchak-textanalysis_DOCUMENTDB",
+                Id = "{Query.id}",
+                PartitionKey = "{Query.partitionKey}"
+            )] ProcessedText document)
+        {
+            log.LogInformation("C# GetProcessedText function received request.");
+
+            if (document != null)
+            {
+                return new OkObjectResult(document);
+            }
+            else
+            {
+                return new NotFoundObjectResult(request.Query);
+            }
+        }
+    }
+}

--- a/ProcessText/ProcessTextFunc/Models/TextExtractionResponse.cs
+++ b/ProcessText/ProcessTextFunc/Models/TextExtractionResponse.cs
@@ -1,22 +1,37 @@
-using System;
+// <copyright file="TextExtractionResponse.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
 
 namespace ProcessTextFunc.Models
 {
     public class TextExtractionResponse
     {
-        public string Title;
-        public string Content;
-        public string Author;
-        public string DatePublished;
-        public string LeadImageUrl;
-        public string Dek;
-        public string NextPageUrl;
-        public string Url;
-        public string Domain;
-        public string Excerpt;
-        public int WordCount;
-        public string Direction;
-        public int TotalPages;
-        public int RenderedPages;
+        public string Title { get; set; }
+
+        public string Content { get; set; }
+
+        public string Author { get; set; }
+
+        public string DatePublished { get; set; }
+
+        public string LeadImageUrl { get; set; }
+
+        public string Dek { get; set; }
+
+        public string NextPageUrl { get; set; }
+
+        public string Url { get; set; }
+
+        public string Domain { get; set; }
+
+        public string Excerpt { get; set; }
+
+        public int WordCount { get; set; }
+
+        public string Direction { get; set; }
+
+        public int TotalPages { get; set; }
+
+        public int RenderedPages { get; set; }
     }
 }

--- a/ProcessText/ProcessTextFunc/ProcessTextFunc.csproj
+++ b/ProcessText/ProcessTextFunc/ProcessTextFunc.csproj
@@ -4,13 +4,14 @@
     <AzureFunctionsVersion>v2</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.ServiceBus" Version="4.1.1" />
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.5" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.CosmosDB" Version="3.0.5" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator" Version="1.1.6" />
-    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.16" />
-    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.0.2" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.ServiceBus" Version="4.1.1"/>
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.5"/>
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.CosmosDB" Version="3.0.5"/>
+    <PackageReference Include="Microsoft.Azure.WebJobs.Script.ExtensionsMetadataGenerator" Version="1.1.6"/>
+    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.16"/>
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2"/>
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.0.2"/>
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118"/>
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/ProcessText/ProcessTextFunc/ProcessTextHttp.cs
+++ b/ProcessText/ProcessTextFunc/ProcessTextHttp.cs
@@ -54,8 +54,10 @@ namespace ProcessTextFunc
                 string message = "Request Body is empty.  Cannot process an empty body.";
                 log.LogError(message);
 
-                httpResponse = new HttpResponseMessage(HttpStatusCode.NoContent);
-                httpResponse.Content = new StringContent(message);
+                httpResponse = new HttpResponseMessage(HttpStatusCode.NoContent)
+                {
+                    Content = new StringContent(message)
+                };
             }
 
             return httpResponse;

--- a/ProcessText/ProcessTextFunc/ProcessTextHttp.cs
+++ b/ProcessText/ProcessTextFunc/ProcessTextHttp.cs
@@ -1,17 +1,21 @@
-using System.Net;
-using System.Net.Http;
-using System.Threading.Tasks;
-using System.IO;
-using Microsoft.Azure.WebJobs;
-using Microsoft.Azure.WebJobs.Extensions.Http;
-using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Logging;
-using ProcessTextFunc.Contracts;
-using ProcessTextFunc.Exceptions;
-using Newtonsoft.Json;
+// <copyright file="ProcessTextHttp.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
 
 namespace ProcessTextFunc
 {
+    using System.IO;
+    using System.Net;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.Azure.WebJobs;
+    using Microsoft.Azure.WebJobs.Extensions.Http;
+    using Microsoft.Extensions.Logging;
+    using Newtonsoft.Json;
+    using ProcessTextFunc.Contracts;
+    using ProcessTextFunc.Exceptions;
+
     public static class ProcessTextHttp
     {
         [FunctionName("ProcessTextHttp")]
@@ -22,8 +26,7 @@ namespace ProcessTextFunc
             [CosmosDB(
                 databaseName: "TextContent",
                 collectionName: "Web",
-                ConnectionStringSetting = "tkawchak-textanalysis_DOCUMENTDB"
-            )] IAsyncCollector<dynamic> outputDocument)
+                ConnectionStringSetting = "tkawchak-textanalysis_DOCUMENTDB")] IAsyncCollector<dynamic> outputDocument)
         {
             HttpResponseMessage httpResponse;
             log.LogInformation("C# ProcessTextHttp function received request.");
@@ -44,10 +47,12 @@ namespace ProcessTextFunc
                 {
                     throw new MissingPropertyException("Title not specified");
                 }
+
                 if (string.IsNullOrWhiteSpace(requestContent.Domain))
                 {
                     throw new MissingPropertyException("Domain not specified.");
                 }
+
                 log.LogInformation($"Received request to store data for webpage at {requestContent.Url}");
 
                 var outputDoc = Utils.Converters.ConvertProcessTextRequestToProcessedTextDocument(requestContent);
@@ -65,7 +70,7 @@ namespace ProcessTextFunc
 
                 httpResponse = new HttpResponseMessage(HttpStatusCode.NoContent)
                 {
-                    Content = new StringContent(message)
+                    Content = new StringContent(message),
                 };
             }
 

--- a/ProcessText/ProcessTextFunc/Utils/Converters.cs
+++ b/ProcessText/ProcessTextFunc/Utils/Converters.cs
@@ -8,6 +8,7 @@ namespace ProcessTextFunc.Utils
         public static ProcessedText ConvertProcessTextRequestToProcessedTextDocument(ProcessTextRequest request)
         {
             var processedText = new ProcessedText {
+                Id = request.Title,
                 Author = request.Author,
                 AutomatedReadabilityIndex = request.AutomatedReadabilityIndex,
                 AverageSentenceLength = request.AverageSentenceLength,
@@ -30,7 +31,8 @@ namespace ProcessTextFunc.Utils
                 SentenceCount = request.SentenceCount,
                 SmogIndex = request.SmogIndex,
                 SyllableCount = request.SyllableCount,
-                Title = request.Title
+                Title = request.Title,
+                Url = request.Url
             };
             return processedText;
         }

--- a/ProcessText/ProcessTextFunc/Utils/Converters.cs
+++ b/ProcessText/ProcessTextFunc/Utils/Converters.cs
@@ -1,13 +1,18 @@
-using System;
-using ProcessTextFunc.Contracts;
+// <copyright file="Converters.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
 
 namespace ProcessTextFunc.Utils
 {
+    using System;
+    using ProcessTextFunc.Contracts;
+
     public static class Converters
     {
         public static ProcessedText ConvertProcessTextRequestToProcessedTextDocument(ProcessTextRequest request)
         {
-            var processedText = new ProcessedText {
+            var processedText = new ProcessedText
+            {
                 Id = request.Title,
                 Author = request.Author,
                 AutomatedReadabilityIndex = request.AutomatedReadabilityIndex,
@@ -32,9 +37,41 @@ namespace ProcessTextFunc.Utils
                 SmogIndex = request.SmogIndex,
                 SyllableCount = request.SyllableCount,
                 Title = request.Title,
-                Url = request.Url
+                Url = request.Url,
             };
             return processedText;
+        }
+
+        public static GetTextResponse ConvertProcessedTextDocumentToGetTextResponse(ProcessedText document)
+        {
+            var getTextResponse = new GetTextResponse
+            {
+                Author = document.Author,
+                AutomatedReadabilityIndex = document.AutomatedReadabilityIndex,
+                AverageSentenceLength = document.AverageSentenceLength,
+                ColemanLiauIndex = document.ColemanLiauIndex,
+                Content = document.Content,
+                DaleChallReadabilityScore = document.DaleChallReadabilityScore,
+                DatePublished = document.DatePublished,
+                DifficultWords = document.DifficultWords,
+                Domain = document.Domain,
+                Excerpt = document.Excerpt,
+                FleschKincaidGrade = document.FleschKincaidGrade,
+                FleshEase = document.FleshEase,
+                GunningFoxIndex = document.GunningFoxIndex,
+                LeadImageUrl = document.LeadImageUrl,
+                LexiconCount = document.LexiconCount,
+                LinsearWriteIndex = document.LinsearWriteIndex,
+                LixReadabilityIndex = document.LixReadabilityIndex,
+                OverallScore = document.OverallScore,
+                ProcessedTime = document.ProcessedTime,
+                SentenceCount = document.SentenceCount,
+                SmogIndex = document.SmogIndex,
+                SyllableCount = document.SyllableCount,
+                Title = document.Title,
+                Url = document.Url,
+            };
+            return getTextResponse;
         }
     }
 }

--- a/ProcessText/ProcessTextFunc/host.json
+++ b/ProcessText/ProcessTextFunc/host.json
@@ -6,5 +6,5 @@
             "protocol": "Https"
         }
     },
-    "functions": ["ProcessTextHttp"]
+    "functions": ["ProcessTextHttp", "GetProcessedText"]
 }


### PR DESCRIPTION
Add an endpoint to get data for a website.  As part of this change, 
* I updated the endpoint to post data for a website to make it easier to query
* I created a new database on the backend to store this data with the proper schema
* Added stylecop and did some refactoring
* Updated the data contracts for requests and responses.